### PR TITLE
Fix Association, カラム

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+public/uploads/*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 |------|----|-------|
 |email|string|null: false|
 |password|string|null: false|
-|nickname|string|null: false|
+|nickname|string|null: false, index: true|
 ### Association
 - has_many :friends
 - has_many :groups

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |groups_users|string|null: false|
-|user_id|integer|null: false, foreign_key: true|
+|group_name|string|null: false, foreign_key: true|
 ### Association
 - has_many :users, through: :groups_users
 - has_many :groups_users

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@
 |------|----|-------|
 |other_user|string|null: false|
 ### Association
-- belongs_to :user
-- belongs_to :friend
+- has_many :users
+- has_many :friends
 - has_many :messages
 
 ## messagesテーブル

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ## messagesテーブル
 |image|text||
-|text|text|null: false|
+|text|text||
 |user_id|integer|null: false, foreign_key: true|
 |friend_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@
 |image|text||
 |text|text||
 |user_id|integer|null: false, foreign_key: true|
-|friend_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group
-- has_many :friends

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|other_user|string|null: false|
+|groups_users|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
 |friend_id|null: false, foreign_key: true|
 ### Association

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |other_user|string|null: false|
+|message_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - has_many :groups
@@ -25,6 +26,8 @@
 |Column|Type|Options|
 |------|----|-------|
 |other_user|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|friend_id|null: false, foreign_key: true|
 ### Association
 - has_many :users
 - has_many :friends
@@ -33,6 +36,9 @@
 ## messagesテーブル
 |image|text||
 |text|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|friend_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 |nickname|string|null: false, index: true|
 ### Association
 - has_many ：groups, through: :groups_users
+- has_many :groups_users
 - has_may :messages
 
 ## groupsテーブル
@@ -18,6 +19,7 @@
 |user_id|integer|null: false, foreign_key: true|
 ### Association
 - has_many :users, through: :groups_users
+- has_many :groups_users
 - has_many :messages
 
 ## groups_usersテーブル

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 |------|----|-------|
 |groups_users|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
-|friend_id|null: false, foreign_key: true|
 ### Association
 - has_many :users
 - has_many :groups_users

--- a/README.md
+++ b/README.md
@@ -12,16 +12,6 @@
 - has_many :groups
 - has_may :messages
 
-## friendsテーブル
-|Column|Type|Options|
-|------|----|-------|
-|other_user|string|null: false|
-|message_id|integer|null: false, foreign_key: true|
-### Association
-- belongs_to :user
-- has_many :groups
-- has_many :messages
-
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@
 - has_many :friends
 - has_many :messages
 
+## groups_usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :group
+- belongs_to :user
+
 ## messagesテーブル
 |image|text||
 |text|text|null: false|

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|groups_users|string|null: false|
 |group_name|string|null: false, foreign_key: true|
 ### Association
 - has_many :users, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -1,24 +1,39 @@
 # README
+# chat-space DB設計
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|nickname|string|null: false|
+### Association
+- has_many :friends
+- has_many :groups
+- has_may :messages
 
-Things you may want to cover:
+## friendsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|other_user|string|null: false|
+### Association
+- belongs_to :user
+- has_many :groups
+- has_many :messages
 
-* Ruby version
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|other_user|string|null: false|
+### Association
+- belongs_to :user
+- belongs_to :friend
+- has_many :messages
 
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+## messagesテーブル
+|image|text||
+|text|text|null: false|
+### Association
+- belongs_to :user
+- belongs_to :group
+- has_many :friends

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 |password|string|null: false|
 |nickname|string|null: false, index: true|
 ### Association
-- has_many :friends
+- has_many ：groups_users
 - has_many :groups
 - has_may :messages
 
@@ -20,7 +20,7 @@
 |friend_id|null: false, foreign_key: true|
 ### Association
 - has_many :users
-- has_many :friends
+- has_many :groups_users
 - has_many :messages
 
 ## groups_usersテーブル

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 |password|string|null: false|
 |nickname|string|null: false, index: true|
 ### Association
-- has_many ：groups_users
-- has_many :groups
+- has_many ：groups, through: :groups_users
 - has_may :messages
 
 ## groupsテーブル
@@ -18,8 +17,7 @@
 |groups_users|string|null: false|
 |user_id|integer|null: false, foreign_key: true|
 ### Association
-- has_many :users
-- has_many :groups_users
+- has_many :users, through: :groups_users
 - has_many :messages
 
 ## groups_usersテーブル


### PR DESCRIPTION
What
usersテーブルとgroupsテーブルに中間テーブルとのアソシエーションを追記
カラム名の変更(user_idは中間テーブルで管理する為)

疑問点
ログインしているユーザー以外に、複数のメンバーがグループに入っている時
groupsテーブルにカラムは必要ないですか？